### PR TITLE
feat: add architect agent for system design

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -155,12 +155,12 @@ lichess/
 
 ### Module Structure (lila/modules/[name]/)
 ```
-src/main/scala/
+src/main/
 ├── [Name].scala        # Main service class
 ├── [Name]Repo.scala    # MongoDB repository
 ├── [Name]Api.scala     # Public API facade
 ├── [Name]Socket.scala  # WebSocket handler (if real-time)
-├── model.scala         # Data models
+├── model.scala         # Data models (or individual model files)
 └── Env.scala           # Dependency injection
 ```
 
@@ -188,7 +188,7 @@ src/
 
 ## Key Files for Reference
 
-- Module registration: `lila/modules/mod/src/main/scala/Env.scala`
+- Module registration: `lila/modules/[module]/src/main/Env.scala`
 - Routes: `lila/conf/routes`
 - API controllers: `lila/app/controllers/Api.scala`
 - WebSocket messages: `lila-ws/src/main/scala/ipc/`


### PR DESCRIPTION
## Summary

Adds a new `architect` specialist agent for system design and API contract definition.

**Expertise areas:**
- Scala/Play Framework patterns (lila backend)
- TypeScript module design (chessground, chessops)
- MongoDB schema design
- WebSocket protocol design
- Multi-repo dependency management

**Output formats:**
- Data model diagrams/definitions
- API endpoint specifications
- Module structure recommendations
- Dependency analysis

**Configuration:**
- Tools: `Read, Glob, Grep, WebFetch, WebSearch` (read-only research)
- Model: `opus` (complex reasoning required)

Fixes #42

## Test Plan

- [ ] Verify agent is discovered by Claude Code
- [ ] Test agent can be invoked via Task tool with `subagent_type=architect`
- [ ] Review output quality on a sample architectural task

🤖 Generated with [Claude Code](https://claude.com/claude-code)