### PR TITLE
feat: enable experimental teams Claude feature

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,2 +1,5 @@
 {
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,19 @@ When work spans multiple repos, use the **same branch name** in all repos for tr
   - `https://api.github.com/repos/...`
 - Examples: `gh issue view`, `gh pr view`, `gh pr list`, `gh api repos/dokipen/lichess-claude/...`
 
+## Agent Teams (Experimental)
+
+This project has the experimental agent teams feature enabled. Agent teams allow coordinating multiple Claude instances working in parallel.
+
+**When to use agent teams:**
+- Parallel code reviews (security, performance, tests simultaneously)
+- Large features with independent pieces that won't conflict
+- Debugging with competing hypotheses
+
+**When to use subagents instead:**
+- Simple delegated tasks with a single focus
+- Tasks that need to report back to the main conversation
+
 ## Verification
 
 ### Scala (lila, lila-ws, scalachess)


### PR DESCRIPTION
## Summary

- Enable the experimental agent teams feature via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` env var in settings.json
- Add documentation to CLAUDE.md explaining when to use agent teams vs subagents

## Changes

- `.claude/settings.json`: Added env var to enable agent teams
- `CLAUDE.md`: Added "Agent Teams (Experimental)" section with usage guidance

Fixes #66