### PR TITLE
feat: generalize repo for sharing by removing hardcoded user/env specifics

### DIFF
--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -16,7 +16,7 @@ name: kebab-case-name          # must match directory name
 description: "This skill should be used when..."  # triggers auto-invocation
 version: 1.0.0
 # Pick ONE invocation mode (omit both = Claude + user can invoke):
-user-invocable: false          # Claude-only (background knowledge)
+user-invokable: false          # Claude-only (background knowledge)
 disable-model-invocation: true # User-only (/slash-command with side effects)
 ```
 
@@ -24,7 +24,7 @@ disable-model-invocation: true # User-only (/slash-command with side effects)
 
 | Skill type | Flag |
 |---|---|
-| Background knowledge / conventions | `user-invocable: false` |
+| Background knowledge / conventions | `user-invokable: false` |
 | Side-effect workflow (creates files, runs git, etc.) | `disable-model-invocation: true` |
 | Both Claude and user should invoke | _(omit both)_ |
 
@@ -49,14 +49,13 @@ disable-model-invocation: true # User-only (/slash-command with side effects)
 
 - Remember this is a multi-repo project
 - Include repo-specific commands where relevant (sbt vs pnpm)
-- Reference the correct GitHub org/repos (dokipen/lila, etc.)
+- Reference the user's GitHub fork repos using `$GITHUB_OWNER` (detected via `gh api user --jq '.login'`)
 
 ## After creating
 
-Commit the new skill to the .claude repo:
+Commit the new skill from the repo root:
 ```bash
-cd /Users/bob/src/lichess/.claude
-git add .
+git add .claude/skills/[skill-name]/
 git commit -m "feat: add [skill-name] skill"
 git push
 ```

--- a/.claude/skills/github-issues/SKILL.md
+++ b/.claude/skills/github-issues/SKILL.md
@@ -1,48 +1,53 @@
 ---
 name: github-issues
 description: Managing GitHub issues with the gh CLI for tracking work across lichess repos
-user-invocable: false
+user-invokable: false
 ---
 
 ## Overview
 
 This skill covers GitHub issue management using the `gh` CLI. Issues are used to track bugs, features, and tasks across the lichess multi-repo project.
 
-**Primary Repos:**
-- `dokipen/lila` - Main server
-- `dokipen/chessground` - Board UI
-- `dokipen/chessops` - Chess logic (TS)
+**Detect repo owner first** (if not already set in this session):
+```bash
+GITHUB_OWNER=$(gh api user --jq '.login')
+```
+
+**Primary Repos** (under `$GITHUB_OWNER`):
+- `$GITHUB_OWNER/lila` - Main server
+- `$GITHUB_OWNER/chessground` - Board UI
+- `$GITHUB_OWNER/chessops` - Chess logic (TS)
 
 ## Listing Issues
 
 ### View open issues
 ```bash
-gh issue list --repo dokipen/lila
+gh issue list --repo $GITHUB_OWNER/lila
 ```
 
 ### Filter by label
 ```bash
-gh issue list --repo dokipen/lila --label "bug"
-gh issue list --repo dokipen/lila --label "enhancement"
+gh issue list --repo $GITHUB_OWNER/lila --label "bug"
+gh issue list --repo $GITHUB_OWNER/lila --label "enhancement"
 ```
 
 ### Search issues
 ```bash
-gh issue list --repo dokipen/lila --search "keyword" --state open
+gh issue list --repo $GITHUB_OWNER/lila --search "keyword" --state open
 ```
 
 ## Reading Issue Details
 
 ```bash
-gh issue view 42 --repo dokipen/lila
-gh issue view 42 --repo dokipen/lila --comments
+gh issue view 42 --repo $GITHUB_OWNER/lila
+gh issue view 42 --repo $GITHUB_OWNER/lila --comments
 ```
 
 ## Creating Issues
 
 ### Standard issue format
 ```bash
-gh issue create --repo dokipen/lila \
+gh issue create --repo $GITHUB_OWNER/lila \
   --title "type: Brief descriptive title" \
   --body "$(cat <<'EOF'
 ## Description
@@ -71,30 +76,30 @@ EOF
 
 ### Edit title or body
 ```bash
-gh issue edit 42 --repo dokipen/lila --title "New title"
+gh issue edit 42 --repo $GITHUB_OWNER/lila --title "New title"
 ```
 
 ### Manage labels
 ```bash
-gh issue edit 42 --repo dokipen/lila --add-label "in-progress"
-gh issue edit 42 --repo dokipen/lila --remove-label "bug"
+gh issue edit 42 --repo $GITHUB_OWNER/lila --add-label "in-progress"
+gh issue edit 42 --repo $GITHUB_OWNER/lila --remove-label "bug"
 ```
 
 ### Close or reopen
 ```bash
-gh issue close 42 --repo dokipen/lila
-gh issue close 42 --repo dokipen/lila --comment "Fixed in PR #45"
+gh issue close 42 --repo $GITHUB_OWNER/lila
+gh issue close 42 --repo $GITHUB_OWNER/lila --comment "Fixed in PR #45"
 ```
 
 ## Commenting on Issues
 
 ```bash
-gh issue comment 42 --repo dokipen/lila --body "Comment text"
+gh issue comment 42 --repo $GITHUB_OWNER/lila --body "Comment text"
 ```
 
 ### Multiline comments
 ```bash
-gh issue comment 42 --repo dokipen/lila --body "$(cat <<'EOF'
+gh issue comment 42 --repo $GITHUB_OWNER/lila --body "$(cat <<'EOF'
 ## Progress Update
 
 - [x] Completed initial research
@@ -115,7 +120,7 @@ Use closing keywords in PR descriptions:
 
 For work spanning multiple repos, note the related repos in the issue:
 ```bash
-gh issue create --repo dokipen/lila \
+gh issue create --repo $GITHUB_OWNER/lila \
   --title "feat: Add feature X" \
   --body "## Description
 This feature requires changes in multiple repos.

--- a/.claude/skills/lead/SKILL.md
+++ b/.claude/skills/lead/SKILL.md
@@ -147,6 +147,17 @@ git worktree prune
 
 ---
 
+## GitHub Owner Detection
+
+**Before any GitHub operations**, detect the repo owner dynamically:
+```bash
+GITHUB_OWNER=$(gh api user --jq '.login')
+```
+
+Use `$GITHUB_OWNER` in all `--repo` flags. **Never hardcode a GitHub username.**
+
+---
+
 ## Issue-First Workflow
 
 **All work MUST be tracked via GitHub issues.**
@@ -154,13 +165,13 @@ git worktree prune
 ### Before Any Work Begins
 
 1. **Identify which repo(s)** need the issue:
-   - lichess-claude changes → `dokipen/lichess-claude`
-   - lila changes → `dokipen/lila`
+   - lichess-claude changes → `$GITHUB_OWNER/lichess-claude`
+   - lila changes → `$GITHUB_OWNER/lila`
    - Multi-repo → Create linked issues or one primary issue
 
 2. **Search for existing issue**:
    ```bash
-   gh issue list --search "[keywords]" --state open --repo dokipen/lichess-claude
+   gh issue list --search "[keywords]" --state open --repo $GITHUB_OWNER/lichess-claude
    ```
 
 3. **If issue exists**: Verify it has clear acceptance criteria
@@ -169,7 +180,7 @@ git worktree prune
 
 5. **Claim the issue**:
    ```bash
-   gh issue edit [NUMBER] --add-label "in-progress" --repo dokipen/lichess-claude
+   gh issue edit [NUMBER] --add-label "in-progress" --repo $GITHUB_OWNER/lichess-claude
    ```
 
 **Do not proceed to Phase 0 until an issue with clear acceptance criteria exists.**
@@ -282,7 +293,7 @@ Reviews are posted as issue/PR comments:
 
 2. **Post setup to issue**:
    ```bash
-   gh issue comment [NUMBER] --repo dokipen/lichess-claude --body "## Setup Complete
+   gh issue comment [NUMBER] --repo $GITHUB_OWNER/lichess-claude --body "## Setup Complete
 
    **Branch:** [issue-number]-[description]
    **Worktrees:**
@@ -305,7 +316,7 @@ Reviews are posted as issue/PR comments:
 4. **Task breakdown**: Create 3-6 discrete units with clear owners
 5. **Post plan to issue** and proceed to implementation:
    ```bash
-   gh issue comment [NUMBER] --repo dokipen/lichess-claude --body "## Implementation Plan
+   gh issue comment [NUMBER] --repo $GITHUB_OWNER/lichess-claude --body "## Implementation Plan
 
    **Tasks:**
    1. [task 1] - [agent]
@@ -367,7 +378,7 @@ Reviews are posted as issue/PR comments:
 
 3. **Post to issue**:
    ```bash
-   gh issue comment [NUMBER] --repo dokipen/lichess-claude --body "## Pre-PR Verification Complete
+   gh issue comment [NUMBER] --repo $GITHUB_OWNER/lichess-claude --body "## Pre-PR Verification Complete
 
    All checks pass. Proceeding to PR creation."
    ```
@@ -387,7 +398,7 @@ Create PRs in each repo with changes. **Use same branch name, reference same iss
 # lichess-claude PR (targeting feature branch if applicable)
 cd .worktrees/[branch]
 # For feature work: use --base [feature-branch] (check issue for branch name!)
-gh pr create --repo dokipen/lichess-claude \
+gh pr create --repo $GITHUB_OWNER/lichess-claude \
   --base [feature-branch] \
   --title "feat: description" \
   --body "## Summary
@@ -410,7 +421,7 @@ Fixes #[ISSUE-NUMBER]"
 # Sub-repo PR (if applicable)
 cd lila/.worktrees/[branch]
 # For feature work: use --base [feature-branch] (check issue for branch name!)
-gh pr create --repo dokipen/lila \
+gh pr create --repo $GITHUB_OWNER/lila \
   --base [feature-branch] \
   --title "feat: description" \
   --body "## Summary
@@ -428,7 +439,7 @@ gh pr create --repo dokipen/lila \
 ### Non-Obvious Code Patterns
 - [Explain any patterns that might not be immediately clear to reviewers]
 
-Related to dokipen/lichess-claude#[ISSUE-NUMBER]"
+Related to $GITHUB_OWNER/lichess-claude#[ISSUE-NUMBER]"
 ```
 
 **Default PR base branches** (when NOT part of a feature):
@@ -438,7 +449,7 @@ Related to dokipen/lichess-claude#[ISSUE-NUMBER]"
 
 **Post to issue** that PRs are ready:
 ```bash
-gh issue comment [NUMBER] --repo dokipen/lichess-claude --body "## PR Created
+gh issue comment [NUMBER] --repo $GITHUB_OWNER/lichess-claude --body "## PR Created
 
 **PR:** [link to PR]
 
@@ -538,8 +549,8 @@ You'll need to be able to explain this code to upstream maintainers.
 
 1. **Merge PRs** (sub-repos first if they're dependencies):
    ```bash
-   gh pr merge --squash --delete-branch --repo dokipen/lila
-   gh pr merge --squash --delete-branch --repo dokipen/lichess-claude
+   gh pr merge --squash --delete-branch --repo $GITHUB_OWNER/lila
+   gh pr merge --squash --delete-branch --repo $GITHUB_OWNER/lichess-claude
    ```
 
 2. **Clean up ALL worktrees**:
@@ -569,7 +580,7 @@ You'll need to be able to explain this code to upstream maintainers.
    git push origin opening-practice
 
    # Example for lichess-claude (feature branch: opening-practice, default: main)
-   cd /path/to/lichess
+   cd "$(git rev-parse --show-toplevel)"
    git fetch origin
    git checkout opening-practice
    git merge origin/main --no-edit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,21 @@ Invoke `/lead` to coordinate the phases (it handles worktree setup automatically
 **For simple tasks** (questions, explanations, code review without changes):
 Respond directly without invoking skills.
 
+## GitHub Owner Detection
+
+This is a multi-repo project where you'll frequently need to reference the user's GitHub fork. **Always detect the GitHub owner dynamically** - never hardcode a username.
+
+At the start of any session that needs GitHub operations, run:
+```bash
+GITHUB_OWNER=$(gh api user --jq '.login')
+```
+
+Then use `$GITHUB_OWNER` in all repo references (e.g., `--repo $GITHUB_OWNER/lichess-claude`).
+
 ## Git Workflow
 
 - The main checkout stays on `main`. All work uses git worktrees via the `/new-work` skill.
-- Before pushing to a branch with an open PR, verify with `gh pr view <branch> --repo dokipen/lichess-claude` that it's still open.
+- Before pushing to a branch with an open PR, verify with `gh pr view <branch> --repo $GITHUB_OWNER/lichess-claude` that it's still open.
 
 ### Multi-Repo Coordination
 
@@ -40,9 +51,11 @@ When developing features intended for upstream contribution to lichess-org repos
 
 #### Active Feature Branches
 
+<!-- Add active feature branches here as they are created -->
+<!-- Example row: | Feature Name | `branch-name` | lichess-claude, lila | In Development | -->
+
 | Feature | Branch Name | Repos | Status |
 |---------|-------------|-------|--------|
-| Opening Practice | `opening-practice` | lichess-claude, lila, lila-ws | In Development |
 
 **Note**: All issues for an active feature should include a "Branch Strategy" section specifying the target feature branch.
 
@@ -50,10 +63,10 @@ When developing features intended for upstream contribution to lichess-org repos
 
 - **Always use `gh` CLI** for all GitHub operations (issues, PRs, comments, reviews, API calls, etc.)
 - **Never use WebFetch or URL-fetching tools** for any GitHub URL, including:
-  - `https://github.com/dokipen/lichess-claude/...`
+  - `https://github.com/{user}/lichess-claude/...`
   - `https://github.com/lichess-org/...`
   - `https://api.github.com/repos/...`
-- Examples: `gh issue view`, `gh pr view`, `gh pr list`, `gh api repos/dokipen/lichess-claude/...`
+- Examples: `gh issue view`, `gh pr view`, `gh pr list`, `gh api repos/$GITHUB_OWNER/lichess-claude/...`
 
 ## Agent Teams (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Lichess requires JDK 21+. After installing, you may need to set `JAVA_HOME`:
 
 ```bash
 # Add to ~/.zshrc or ~/.bash_profile
-export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+export JAVA_HOME=$(brew --prefix openjdk@21)
 export PATH="$JAVA_HOME/bin:$PATH"
 ```
 
@@ -91,7 +91,7 @@ brew services start mongodb-community@8.0
 mongosh --eval "db.runCommand({ ping: 1 })"
 ```
 
-Data is stored at `/opt/homebrew/var/mongodb` by default.
+Data is stored at `$(brew --prefix)/var/mongodb` by default.
 
 #### Redis
 
@@ -163,7 +163,7 @@ In a terminal:
 
 ```bash
 cd lila-ws
-JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt "run -Dcsrf.origin=http://localhost:9663"
+JAVA_HOME=$(brew --prefix openjdk@21) sbt "run -Dcsrf.origin=http://localhost:9663"
 ```
 
 Wait until you see: `Listening to 9664`
@@ -174,7 +174,7 @@ In another terminal:
 
 ```bash
 cd lila
-JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt run
+JAVA_HOME=$(brew --prefix openjdk@21) sbt run
 ```
 
 First run compiles everything (~5 minutes). Wait until you see:
@@ -237,7 +237,7 @@ cd lila
 ## Git Workflow
 
 Repositories are configured with:
-- `origin` → Your fork (dokipen/*)
+- `origin` → Your fork ({your-username}/*)
 - `upstream` → Official repo (lichess-org/*)
 
 ```bash
@@ -260,17 +260,6 @@ git push origin my-feature
 | MongoDB | 27017 | Database |
 | Redis | 6379 | Cache & real-time |
 
-## Key Modules for Opening Trainer
-
-If working on opening/practice features, focus on:
-
-| Component | Backend | Frontend |
-|-----------|---------|----------|
-| Studies | `lila/modules/study/` | `lila/ui/analyse/src/study/` |
-| Practice Mode | `lila/modules/practice/` | `lila/ui/analyse/src/practice/` |
-| Puzzles | `lila/modules/puzzle/` | `lila/ui/puzzle/` |
-| Openings | `lila/modules/opening/` | — |
-
 ## Troubleshooting
 
 ### sbt not found
@@ -281,7 +270,7 @@ source ~/.zprofile  # or ~/.bash_profile
 
 ### Java version issues
 ```bash
-export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+export JAVA_HOME=$(brew --prefix openjdk@21)
 export PATH="$JAVA_HOME/bin:$PATH"
 ```
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -206,7 +206,7 @@ init_db_seed() {
 
     if [ ! -d "venv" ]; then
         info "Setting up Python virtual environment for db seeding..."
-        /opt/homebrew/bin/python3.12 -m venv venv
+        python3.12 -m venv venv
         source venv/bin/activate
         pip install -r requirements.txt
         deactivate
@@ -228,11 +228,11 @@ print_summary() {
     echo ""
     echo "1. Start lila-ws (Terminal 1):"
     echo "   cd lila-ws"
-    echo "   JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt 'run -Dcsrf.origin=http://localhost:9663'"
+    echo "   JAVA_HOME=$(brew --prefix openjdk@21) sbt 'run -Dcsrf.origin=http://localhost:9663'"
     echo ""
     echo "2. Start lila (Terminal 2):"
     echo "   cd lila"
-    echo "   JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt run"
+    echo "   JAVA_HOME=$(brew --prefix openjdk@21) sbt run"
     echo ""
     echo "3. Open http://localhost:9663"
     echo ""

--- a/scripts/lib/github-owner.sh
+++ b/scripts/lib/github-owner.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Detect the GitHub username of the currently authenticated user.
+# Sources in order: GH_OWNER env var, gh CLI auth.
+#
+# Usage (in other scripts):
+#   source "$(dirname "$0")/lib/github-owner.sh"
+#   echo "Your fork: $GITHUB_OWNER/lila"
+
+if [ -n "$GH_OWNER" ]; then
+  GITHUB_OWNER="$GH_OWNER"
+elif command -v gh &> /dev/null && gh auth status &> /dev/null; then
+  GITHUB_OWNER=$(gh api user --jq '.login' 2>/dev/null)
+fi
+
+if [ -z "$GITHUB_OWNER" ]; then
+  echo "Warning: Could not detect GitHub username." >&2
+  echo "Set GH_OWNER env var or run 'gh auth login'." >&2
+fi
+
+export GITHUB_OWNER

--- a/scripts/seed-db.sh
+++ b/scripts/seed-db.sh
@@ -10,7 +10,7 @@ cd "$ROOT_DIR/lila-db-seed/spamdb"
 
 if [ ! -d "venv" ]; then
     echo "Setting up Python virtual environment..."
-    /opt/homebrew/bin/python3.12 -m venv venv
+    python3.12 -m venv venv
     source venv/bin/activate
     pip install -r requirements.txt
 else

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -11,10 +11,12 @@ brew services start redis 2>/dev/null || echo "Redis already running or failed t
 echo ""
 echo "Services started. Now run in separate terminals:"
 echo ""
+JAVA_HOME_PATH=$(brew --prefix openjdk@21 2>/dev/null || echo "/opt/homebrew/opt/openjdk@21")
+
 echo "Terminal 1 (lila-ws):"
-echo "  cd lila-ws && JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt 'run -Dcsrf.origin=http://localhost:9663'"
+echo "  cd lila-ws && JAVA_HOME=$JAVA_HOME_PATH sbt 'run -Dcsrf.origin=http://localhost:9663'"
 echo ""
 echo "Terminal 2 (lila):"
-echo "  cd lila && JAVA_HOME=/opt/homebrew/opt/openjdk@21 sbt run"
+echo "  cd lila && JAVA_HOME=$JAVA_HOME_PATH sbt run"
 echo ""
 echo "Then open: http://localhost:9663"


### PR DESCRIPTION
## Summary
- Replace all hardcoded `dokipen` GitHub username references with dynamic `$GITHUB_OWNER` detection via `gh api user --jq '.login'`
- Replace hardcoded `/opt/homebrew` paths with `$(brew --prefix)` for Apple Silicon + Intel Mac compatibility
- Remove hardcoded `/Users/bob` absolute path from create-skill skill
- Remove project-specific "Opening Trainer" module list from README
- Clear the active feature branches table in CLAUDE.md (project-specific state)
- Fix `user-invocable` typo to `user-invokable` in skill frontmatter

## How It Works

### Implementation Approach
Instead of using environment variables or `.env` files (which adds complexity), the approach uses:
1. **Dynamic GitHub owner detection** - Skills instruct Claude to run `GITHUB_OWNER=$(gh api user --jq '.login')` at the start of sessions needing GitHub operations, then use `$GITHUB_OWNER` in all `--repo` flags
2. **Homebrew prefix detection** - Scripts use `$(brew --prefix openjdk@21)` instead of hardcoded `/opt/homebrew/opt/openjdk@21`, making them work on both Apple Silicon (`/opt/homebrew`) and Intel Macs (`/usr/local`)
3. **Relative paths** - Removed absolute `/Users/bob/...` paths in favor of relative paths from repo root

### Key Decisions
- **Dynamic detection over config files**: Using `gh api user` and `brew --prefix` at runtime avoids the need for a separate setup/config step that users might forget
- **$GITHUB_OWNER in markdown**: Since these files are read by Claude (not executed directly), the `$GITHUB_OWNER` pattern serves as both a variable for shell commands and a clear signal that the value should be dynamically resolved
- **Helper script `scripts/lib/github-owner.sh`**: Provides a reusable shell-sourceable helper for scripts that need the GitHub owner, with fallback to `GH_OWNER` env var

### Non-Obvious Code Patterns
- The `start-services.sh` script retains `/opt/homebrew/opt/openjdk@21` as a fallback value when `brew --prefix` fails (e.g., if brew is not in PATH) - this is intentional defensive coding

Fixes #72